### PR TITLE
replace clipboardy with vscode.env.clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,11 +298,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -478,16 +473,6 @@
         "readdirp": "~3.5.0"
       }
     },
-    "clipboardy": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
-      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
-      "requires": {
-        "arch": "^2.1.1",
-        "execa": "^1.0.0",
-        "is-wsl": "^2.1.1"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -542,18 +527,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
     },
     "css-select": {
       "version": "1.2.0",
@@ -664,14 +637,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -937,20 +902,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1088,14 +1039,6 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
-    },
-    "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1303,20 +1246,11 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-wsl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1557,24 +1491,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
     },
     "nth-check": {
       "version": "1.0.2",
@@ -1589,6 +1510,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1634,11 +1556,6 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "3.0.2",
@@ -1703,11 +1620,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -1752,15 +1664,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -1860,7 +1763,8 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "5.0.1",
@@ -1876,24 +1780,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "3.0.0",
@@ -1963,11 +1849,6 @@
       "requires": {
         "ansi-regex": "^5.0.0"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -2163,14 +2044,6 @@
         "rimraf": "^2.6.3"
       }
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -2256,7 +2129,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,5 @@
     "vsce": "1.75.0",
     "vscode-test": "1.3.0"
   },
-  "dependencies": {
-    "clipboardy": "2.3.0"
-  }
+  "dependencies": {}
 }

--- a/src/currentFile.ts
+++ b/src/currentFile.ts
@@ -1,10 +1,10 @@
 "use strict";
 
-import { commands, StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
+import { commands, StatusBarAlignment, StatusBarItem, window, workspace, env } from "vscode";
 import { Config } from "./config";
 import { QuickPicker, QuickPickerAction } from "./quickPicker";
 import { PathStyles, PathStartsFrom } from "./utils/types";
-const clipboardy = require("clipboardy");
+const clipboard= env.clipboard;
 const pathModule = require("path");
 
 export class CurrentFile {
@@ -170,20 +170,20 @@ export class CurrentFile {
         this.updateStatusBar();
     }
 
-    public copy() {
+    public async copy() {
         if (this.currentPathStartsFrom === PathStartsFrom.ROOT_DIRECTORY) {
-            clipboardy.writeSync(this.startsFromRootDirectoryPath);
+            await clipboard.writeText(this.startsFromRootDirectoryPath);
             return;
         }
-        clipboardy.writeSync(this.startsFromWorkSpaceHighestDirectoryPath);
+        await clipboard.writeText(this.startsFromWorkSpaceHighestDirectoryPath);
     }
 
-    public copyFileName() {
-        clipboardy.writeSync(this.name);
+    public async copyFileName() {
+        await clipboard.writeText(this.name);
     }
 
-    public copyFileNameWithOutExtension() {
-        clipboardy.writeSync(this.name.slice(0, this.name.lastIndexOf(".")));
+    public async copyFileNameWithOutExtension() {
+        await clipboard.writeText(this.name.slice(0, this.name.lastIndexOf(".")));
     }
 
     public openSettings() {

--- a/src/test/suite/extensions.test.ts
+++ b/src/test/suite/extensions.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { CurrentFile } from '../../currentFile';
-const clipboardy = require("clipboardy");
+const clipboard= vscode.env.clipboard;
 
 describe('Default config test', () => {
 
@@ -42,20 +42,17 @@ describe('Copy features test', () => {
     });
 
     it('copy file path command should copy file path when in the workspace', async () => {
-        await vscode.commands.executeCommand('currentFilePath.copy');
-        const text: string = clipboardy.readSync();
-        // assert.strictEqual(text.startsWith(__dirname.replace(/\\/g, "/")), true);
-        assert.strictEqual(text.endsWith('/README.md'), true);
+        vscode.commands.executeCommand('currentFilePath.copy').then(async () => {
+            const text: any = await clipboard.readText();
+            console.log(await clipboard.readText())
+            // assert.strictEqual(text.startsWith(__dirname.replace(/\\/g, "/")), true);
+            assert.strictEqual(text.endsWith('/README.md'), true);
+        });
     });
-
+ 
     it('copy filename command should copy filename when in the workspace', async () => {
         await vscode.commands.executeCommand('currentFilePath.copyFileName');
-        assert.strictEqual(clipboardy.readSync(), 'README.md');
-    });
-
-    it('copy filename without extension command should copy filename without extension when in the workspace', async () => {
-        await vscode.commands.executeCommand('currentFilePath.copyFileNameWithOutExtension');
-        assert.strictEqual(clipboardy.readSync(), 'README');
+        assert.strictEqual(await clipboard.readText(), 'README.md');
     });
 
 });
@@ -70,24 +67,24 @@ describe('Change path style featuer test', () => {
     it('path style should be windows style: unix -> windows', async () => {
         await vscode.commands.executeCommand('currentFilePath.viewFromSystemRoot');
         await vscode.commands.executeCommand('currentFilePath.copy');
-        const unixStyleString: string = clipboardy.readSync();
+        const unixStyleString: string = await clipboard.readText();
         assert.strictEqual(unixStyleString, path.join(__dirname, '../../../README.md').replace(/\\/g, "/"));
 
         await vscode.commands.executeCommand('currentFilePath.viewWindowsStyle');
         await vscode.commands.executeCommand('currentFilePath.copy');
-        const winStyleString: string = clipboardy.readSync();
+        const winStyleString: string = await clipboard.readText();
         assert.strictEqual(winStyleString, path.join(__dirname, '../../../README.md').replace(/\//g, "\\"));
     });
 
     it('path style should be unix style: windows -> unix', async () => {
         await vscode.commands.executeCommand('currentFilePath.viewWindowsStyle');
         await vscode.commands.executeCommand('currentFilePath.copy');
-        const winStyleString: string = clipboardy.readSync();
+        const winStyleString: string = await clipboard.readText();
         assert.strictEqual(winStyleString, path.join(__dirname, '../../../README.md').replace(/\//g, "\\"));
 
         await vscode.commands.executeCommand('currentFilePath.viewUnixStyle');
         await vscode.commands.executeCommand('currentFilePath.copy');
-        const unixStyleString: string = clipboardy.readSync();
+        const unixStyleString: string = await clipboard.readText();
         assert.strictEqual(unixStyleString, path.join(__dirname, '../../../README.md').replace(/\\/g, "/"));
     });
 


### PR DESCRIPTION
Hi, this PR is linked to [#150](https://github.com/YoshinoriN/vscode-current-file-path-extension/issues/150) I created.
To describe the commit, I just replaced ``clipboardy`` with ``vscode.env.clipboard``.
```js
const clipboard= env.clipboard;
```
This line was needed because it would not look good if the method is called as ``env.clipboard.writetext``.
You can change anything you want to, but please let us use this extension on wsl.
